### PR TITLE
Display error when CORS server not running

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,13 @@ const currencySelect = document.querySelector('#steamCurrencySelect')
 
 submitBtn.addEventListener("click", processSearchQuery);
 
+window.addEventListener("unhandledrejection", function(promiseRejectionEvent) { 
+    if (promiseRejectionEvent.reason.message === 'Failed to fetch') {
+        displayError("Failed to connect to the API. Make sure your localhost CORS server is running.");
+        return;
+    }
+    console.log(`An unexpector promise error occured: ${promiseRejectionEvent.reason.message}`);
+});
 
 function processSearchQuery(e) {
     e.preventDefault(); // to prevent page from refreshing when input submitted
@@ -36,7 +43,7 @@ async function searchByName(wantedName) {
         }
     });
     if (matching_ids.length === 0) {
-        displayError("Couldn't find a game with that name");
+        displayError("Couldn't find a game with that name.");
         return;
     }
     displayError() // this search is valid, so remove any displayed error
@@ -181,10 +188,13 @@ function displayError(errorMessage) {
         if (errorMessage === undefined) return;
     }
     // Display new error message
+    const errorContainer = document.getElementById("error-container");
+    
     const p = document.createElement("p");
     p.classList.add("error");
     p.innerText = errorMessage;
-    body.append(p);
+    
+    errorContainer.append(p);
 }
 
 function generateGeneralData(data) {

--- a/script.js
+++ b/script.js
@@ -5,12 +5,8 @@ const currencySelect = document.querySelector('#steamCurrencySelect')
 
 submitBtn.addEventListener("click", processSearchQuery);
 
-window.addEventListener("unhandledrejection", function(promiseRejectionEvent) { 
-    if (promiseRejectionEvent.reason.message === 'Failed to fetch') {
-        displayError("Failed to connect to the API. Make sure your localhost CORS server is running.");
-        return;
-    }
-    console.log(`An unexpector promise error occured: ${promiseRejectionEvent.reason.message}`);
+window.addEventListener("unhandledrejection", function() { 
+    displayError("Something went wrong. Make sure your localhost CORS server is running.");
 });
 
 function processSearchQuery(e) {


### PR DESCRIPTION
As the title says.

When a user tries to load the website before starting the localhost CORS server, we send an error message:
![image](https://user-images.githubusercontent.com/114286962/198590464-5b8ecb18-615e-41d3-84d3-804c656da62d.png)

Note that the error message is a generic one (any promise error will display it), and that the error is now displayed in the `error-container` div, as intended, rather than below the main section.